### PR TITLE
Small Makefile modification to bring down binary size.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+NAME=gaia
+GO_LDFLAGS_STATIC=-ldflags "-s -w -extldflags -static"
+
 default: dev
 
 dev:
@@ -17,6 +20,9 @@ static_assets:
 	rice embed-go
 
 compile_backend:
-	env GOOS=linux GOARCH=amd64 go build -o gaia-linux-amd64 ./cmd/gaia/main.go
+	env GOOS=linux GOARCH=amd64 go build $(GO_LDFLAGS_STATIC) -o $(NAME)-linux-amd64 ./cmd/gaia/main.go
+
+test:
+	go test -v ./...
 
 release: compile_frontend static_assets compile_backend

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,7 @@ compile_backend:
 test:
 	go test -v ./...
 
+test-cover:
+	go test -v ./... --coverprofile=cover.out
+
 release: compile_frontend static_assets compile_backend


### PR DESCRIPTION
This brings down the binary size from 21MB to 11MB.

Also, I'm planning on adding a coverage report for all packages in `test-cover` so hold off on merging until then if you so please. :)