### PR TITLE
Fixed and cleaned up store test

### DIFF
--- a/pipeline/git_test.go
+++ b/pipeline/git_test.go
@@ -9,15 +9,12 @@ import (
 
 func TestGitCloneRepo(t *testing.T) {
 	repo := &gaia.GitRepo{
-		URL: "https://github.com/gaia-pipeline/gaia",
+		URL:       "https://github.com/gaia-pipeline/gaia",
+		LocalDest: "tmp",
 	}
+	// always ensure that tmp folder is cleaned up
+	defer os.RemoveAll("tmp")
 	err := gitCloneRepo(repo)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// clean up
-	err = os.RemoveAll("tmp")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -39,12 +39,7 @@ func TestInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	// cleanup
-	err = os.Remove("data/gaia.db")
-	if err != nil {
-		t.Fatal(err)
-	}
+	defer os.Remove("data/gaia.db")
 }
 
 func TestUserGet(t *testing.T) {
@@ -52,6 +47,7 @@ func TestUserGet(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.Remove("data/gaia.db")
 
 	u := &gaia.User{}
 	u.Username = "testuser"
@@ -77,12 +73,6 @@ func TestUserGet(t *testing.T) {
 	if user == nil {
 		t.Fatalf("Expected user %v. Got nil.", u.Username)
 	}
-
-	// cleanup
-	err = os.Remove("data/gaia.db")
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestUserPut(t *testing.T) {
@@ -90,18 +80,13 @@ func TestUserPut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.Remove("data/gaia.db")
 
 	u := &gaia.User{}
 	u.Username = "testuser"
 	u.Password = "12345!#+21+"
 	u.DisplayName = "Test"
 	err = store.UserPut(u, true)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// cleanup
-	err = os.Remove("data/gaia.db")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,6 +97,7 @@ func TestUserAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.Remove("data/gaia.db")
 
 	u := &gaia.User{}
 	u.Username = "testuser"
@@ -149,16 +135,10 @@ func TestUserAuth(t *testing.T) {
 	u.Username = "testuser"
 	u.Password = "wrongpassword"
 	r, err = store.UserAuth(u, true)
-	if err != nil {
+	if err == nil {
 		t.Fatal(err)
 	}
 	if r != nil {
 		t.Fatalf("Expected nil object here. User shouldnt be valid")
-	}
-
-	// cleanup
-	err = os.Remove("data/gaia.db")
-	if err != nil {
-		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Store test was invalidly trying to cleanup data folder when a test failed. Because db file cleanup wasn't a defer call.

This meant that the cleanup after `m.Run()` wasn't able to cleanup data folder as it wasn't empty.

Also, I'm not sure what the last test case was supposed to test, but it wasn't working as is, because `testuser` was a valid user and it was trying to log - in with an invalid password.