### PR TITLE
Refactoring and test fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GO_LDFLAGS_STATIC=-ldflags "-s -w -extldflags -static"
 default: dev
 
 dev:
-	go run ./cmd/gaia/main.go -homepath=${PWD}/tmp -dev=true -poll=true
+	go run ./cmd/gaia/main.go -homepath=${PWD}/tmp -dev=true
 
 compile_frontend:
 	cd ./frontend && \

--- a/handlers/user_test.go
+++ b/handlers/user_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http/httptest"
 
 	"io/ioutil"
-	"os"
 
 	"crypto/rand"
 	"crypto/rsa"
@@ -21,15 +20,11 @@ import (
 )
 
 func TestUserLoginHMACKey(t *testing.T) {
-
-	dataDir, err := ioutil.TempDir("", "hmac")
-	if err != nil {
-		t.Fatalf("error creating data dir %v", err.Error())
-	}
+	tmp, _ := ioutil.TempDir("", "TestUserLoginHMACKey")
+	dataDir := tmp
 
 	defer func() {
 		gaia.Cfg = nil
-		os.RemoveAll(dataDir)
 	}()
 
 	gaia.Cfg = &gaia.Config{
@@ -77,14 +72,11 @@ func TestUserLoginHMACKey(t *testing.T) {
 }
 
 func TestUserLoginRSAKey(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "rsa")
-	if err != nil {
-		t.Fatalf("error creating data dir %v", err.Error())
-	}
+	tmp, _ := ioutil.TempDir("", "TestUserLoginRSAKey")
+	dataDir := tmp
 
 	defer func() {
 		gaia.Cfg = nil
-		os.RemoveAll(dataDir)
 	}()
 
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)

--- a/handlers/vault_test.go
+++ b/handlers/vault_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/gaia-pipeline/gaia"
@@ -16,14 +15,10 @@ import (
 )
 
 func TestVaultWorkflowAddListDelete(t *testing.T) {
-	dataDir, err := ioutil.TempDir("", "temp")
-	if err != nil {
-		t.Fatalf("error creating data dir %v", err.Error())
-	}
+	dataDir, _ := ioutil.TempDir("", "TestVaultWorkflowAddListDelete")
 
 	defer func() {
 		gaia.Cfg = nil
-		os.RemoveAll(dataDir)
 	}()
 
 	gaia.Cfg = &gaia.Config{
@@ -33,16 +28,14 @@ func TestVaultWorkflowAddListDelete(t *testing.T) {
 		VaultPath: dataDir,
 	}
 
-	dataStore, _ := services.StorageService()
-	err = dataStore.Init()
-	if err != nil {
-		t.Fatalf("cannot initialize store: %v", err.Error())
-	}
-
-	_, err = services.CertificateService()
+	ce, err := services.CertificateService()
 	if err != nil {
 		t.Fatalf("cannot initialize certificate service: %v", err.Error())
 	}
+
+	// Make sure the cert exists because if the service was alreay
+	// created, Init won't be called again.
+	ce.CreateSignedCert()
 
 	e := echo.New()
 	InitHandlers(e)

--- a/pipeline/build_golang_test.go
+++ b/pipeline/build_golang_test.go
@@ -29,7 +29,7 @@ func (m *mockStorer) PipelinePut(p *gaia.Pipeline) error {
 }
 
 func TestPrepareEnvironmentGo(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestPrepareEnvironmentGo")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	b := new(BuildPipelineGolang)
@@ -60,7 +60,7 @@ func TestExecuteBuildGo(t *testing.T) {
 	defer func() {
 		execCommandContext = exec.CommandContext
 	}()
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildGo")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	b := new(BuildPipelineGolang)
@@ -117,7 +117,7 @@ func TestExecuteBuildContextTimeoutGo(t *testing.T) {
 		execCommandContext = exec.CommandContext
 		buildKillContext = false
 	}()
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildContextTimeoutGo")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -139,7 +139,7 @@ func TestExecuteBuildContextTimeoutGo(t *testing.T) {
 }
 
 func TestExecuteBuildBinaryNotFoundErrorGo(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildBinaryNotFoundErrorGo")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -164,7 +164,7 @@ func TestExecuteBuildBinaryNotFoundErrorGo(t *testing.T) {
 }
 
 func TestCopyBinaryGo(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCopyBinaryGo")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -199,7 +199,7 @@ func TestCopyBinaryGo(t *testing.T) {
 }
 
 func TestCopyBinarySrcDoesNotExistGo(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCopyBinarySrcDoesNotExistGo")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger

--- a/pipeline/build_java_test.go
+++ b/pipeline/build_java_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestPrepareEnvironmentJava(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestPrepareEnvironmentJava")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	b := new(BuildPipelineJava)
@@ -48,7 +48,7 @@ func TestExecuteBuildJava(t *testing.T) {
 	defer func() {
 		execCommandContext = exec.CommandContext
 	}()
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildJava")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	b := new(BuildPipelineJava)
@@ -73,7 +73,7 @@ func TestExecuteBuildContextTimeoutJava(t *testing.T) {
 		execCommandContext = exec.CommandContext
 		buildKillContext = false
 	}()
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildContextTimeoutJava")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -97,7 +97,7 @@ func TestExecuteBuildContextTimeoutJava(t *testing.T) {
 }
 
 func TestCopyBinaryJava(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCopyBinaryJava")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -134,7 +134,7 @@ func TestCopyBinaryJava(t *testing.T) {
 }
 
 func TestCopyBinarySrcDoesNotExistJava(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCopyBinarySrcDoesNotExistJava")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -169,7 +169,7 @@ func (m *javaMockStorer) PipelinePut(p *gaia.Pipeline) error {
 }
 
 func TestSavePipelineJava(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestSavePipelineJava")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	m := new(javaMockStorer)

--- a/pipeline/create_pipeline_test.go
+++ b/pipeline/create_pipeline_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/gaia-pipeline/gaia/services"
@@ -30,7 +29,7 @@ func (mcp *mockCreatePipelineStore) PipelinePut(p *gaia.Pipeline) error {
 }
 
 func TestCreatePipelineUnknownType(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCreatePipelineUnknownType")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	buf := new(bytes.Buffer)
@@ -41,6 +40,7 @@ func TestCreatePipelineUnknownType(t *testing.T) {
 	})
 	mcp := new(mockCreatePipelineStore)
 	services.MockStorageService(mcp)
+	defer func() { services.MockStorageService(nil) }()
 	cp := new(gaia.CreatePipeline)
 	cp.Pipeline.Type = gaia.PTypeUnknown
 	CreatePipeline(cp)
@@ -53,7 +53,7 @@ func TestCreatePipelineUnknownType(t *testing.T) {
 }
 
 func TestCreatePipelineMissingGitURL(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCreatePipelineMissingGitURL")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	buf := new(bytes.Buffer)
@@ -64,6 +64,7 @@ func TestCreatePipelineMissingGitURL(t *testing.T) {
 	})
 	mcp := new(mockCreatePipelineStore)
 	services.MockStorageService(mcp)
+	defer func() { services.MockStorageService(nil) }()
 	cp := new(gaia.CreatePipeline)
 	cp.Pipeline.Type = gaia.PTypeGolang
 	CreatePipeline(cp)
@@ -73,7 +74,7 @@ func TestCreatePipelineMissingGitURL(t *testing.T) {
 }
 
 func TestCreatePipelineFailedToUpdatePipeline(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCreatePipelineFailedToUpdatePipeline")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	buf := new(bytes.Buffer)
@@ -85,9 +86,10 @@ func TestCreatePipelineFailedToUpdatePipeline(t *testing.T) {
 	mcp := new(mockCreatePipelineStore)
 	mcp.Error = errors.New("failed")
 	services.MockStorageService(mcp)
+	defer func() { services.MockStorageService(nil) }()
 	cp := new(gaia.CreatePipeline)
 	cp.Pipeline.Type = gaia.PTypeGolang
-	cp.Pipeline.Repo.URL = "https://github.com/gaia-pipeline/go-test-example"
+	cp.Pipeline.Repo.URL = "https://github.com/gaia-pipeline/pipeline-test"
 	CreatePipeline(cp)
 	body, _ := ioutil.ReadAll(buf)
 	if !bytes.Contains(body, []byte("cannot put create pipeline into store: error=failed")) {
@@ -96,10 +98,9 @@ func TestCreatePipelineFailedToUpdatePipeline(t *testing.T) {
 }
 
 func TestCreatePipeline(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCreatePipeline")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
-	defer os.Remove("_golang")
 	buf := new(bytes.Buffer)
 	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
 		Level:  hclog.Trace,
@@ -108,9 +109,10 @@ func TestCreatePipeline(t *testing.T) {
 	})
 	mcp := new(mockCreatePipelineStore)
 	services.MockStorageService(mcp)
+	defer func() { services.MockStorageService(nil) }()
 	cp := new(gaia.CreatePipeline)
 	cp.Pipeline.Type = gaia.PTypeGolang
-	cp.Pipeline.Repo.URL = "https://github.com/gaia-pipeline/go-test-example"
+	cp.Pipeline.Repo.URL = "https://github.com/gaia-pipeline/pipeline-test"
 	CreatePipeline(cp)
 	if cp.StatusType != gaia.CreatePipelineSuccess {
 		t.Fatal("pipeline status was not success. was: ", cp.StatusType)

--- a/pipeline/git_test.go
+++ b/pipeline/git_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -13,7 +14,7 @@ import (
 
 func TestGitCloneRepo(t *testing.T) {
 	repo := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 	}
 	// always ensure that tmp folder is cleaned up
@@ -25,7 +26,7 @@ func TestGitCloneRepo(t *testing.T) {
 }
 
 func TestUpdateAllPipelinesRepositoryNotFound(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestUpdateAllPipelinesRepositoryNotFound")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	// Initialize shared logger
@@ -57,7 +58,7 @@ func TestUpdateAllPipelinesAlreadyUpToDate(t *testing.T) {
 		Name:   "Gaia",
 	})
 	repo := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 	}
 	// always ensure that tmp folder is cleaned up
@@ -90,7 +91,7 @@ func TestUpdateAllPipelinesAlreadyUpToDateWithMoreThanOnePipeline(t *testing.T) 
 		Name:   "Gaia",
 	})
 	repo := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 	}
 	// always ensure that tmp folder is cleaned up
@@ -132,7 +133,7 @@ func TestUpdateAllPipelinesHundredPipelines(t *testing.T) {
 		Name:   "Gaia",
 	})
 	repo := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 	}
 	// always ensure that tmp folder is cleaned up
@@ -159,7 +160,7 @@ func TestUpdateAllPipelinesHundredPipelines(t *testing.T) {
 
 func TestGetAuthInfoWithUsernameAndPassword(t *testing.T) {
 	repoWithUsernameAndPassword := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 		Username:  "username",
 		Password:  "password",
@@ -179,7 +180,7 @@ Xbs5AQIEIzWnmQIFAOEml+E=
 -----END RSA PRIVATE KEY-----
 `
 	repoWithValidPrivateKey := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 		PrivateKey: gaia.PrivateKey{
 			Key:      samplePrivateKey,
@@ -193,7 +194,7 @@ Xbs5AQIEIzWnmQIFAOEml+E=
 	}
 
 	repoWithInvalidPrivateKey := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 		PrivateKey: gaia.PrivateKey{
 			Key:      "random_key",
@@ -209,7 +210,7 @@ Xbs5AQIEIzWnmQIFAOEml+E=
 
 func TestGetAuthInfoEmpty(t *testing.T) {
 	repoWithoutAuthInfo := &gaia.GitRepo{
-		URL:       "https://github.com/gaia-pipeline/go-test-example",
+		URL:       "https://github.com/gaia-pipeline/pipeline-test",
 		LocalDest: "tmp",
 	}
 	auth, _ := getAuthInfo(repoWithoutAuthInfo)

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -115,7 +115,7 @@ func TestReplace(t *testing.T) {
 		Name: "Pipeline A",
 		Type: gaia.PTypeGolang,
 		Repo: gaia.GitRepo{
-			URL:       "https://github.com/gaia-pipeline/go-test-example-1",
+			URL:       "https://github.com/gaia-pipeline/pipeline-test-1",
 			LocalDest: "tmp",
 		},
 		Created: time.Now(),
@@ -126,7 +126,7 @@ func TestReplace(t *testing.T) {
 		Name: "Pipeline A",
 		Type: gaia.PTypeGolang,
 		Repo: gaia.GitRepo{
-			URL:       "https://github.com/gaia-pipeline/go-test-example-2",
+			URL:       "https://github.com/gaia-pipeline/pipeline-test-2",
 			LocalDest: "tmp",
 		},
 		Created: time.Now(),
@@ -139,7 +139,7 @@ func TestReplace(t *testing.T) {
 	}
 
 	p := ap.GetByName("Pipeline A")
-	if p.Repo.URL != "https://github.com/gaia-pipeline/go-test-example-2" {
+	if p.Repo.URL != "https://github.com/gaia-pipeline/pipeline-test-2" {
 		t.Fatalf("The pipeline repo URL should have been replaced")
 	}
 }
@@ -255,17 +255,20 @@ func TestRemoveDeletedPipelines(t *testing.T) {
 }
 
 func TestRenameBinary(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestRenameBinary")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.PipelinePath = tmp
+	gaia.Cfg.HomePath = tmp
+	gaia.Cfg.DataPath = tmp
+	defer os.Remove("_golang")
 
 	p := gaia.Pipeline{
-		Name:    "Pipeline A",
+		Name:    "PipelineA",
 		Type:    gaia.PTypeGolang,
 		Created: time.Now(),
 	}
 
-	newName := "Pipeline B"
+	newName := "PipelineB"
 
 	src := filepath.Join(tmp, appendTypeToName(p.Name, p.Type))
 	dst := filepath.Join(tmp, appendTypeToName(newName, p.Type))
@@ -292,12 +295,14 @@ func TestRenameBinary(t *testing.T) {
 }
 
 func TestDeleteBinary(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestDeleteBinary")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.PipelinePath = tmp
+	gaia.Cfg.HomePath = tmp
+	gaia.Cfg.DataPath = tmp
 
 	p := gaia.Pipeline{
-		Name:    "Pipeline A",
+		Name:    "PipelineA",
 		Type:    gaia.PTypeGolang,
 		Created: time.Now(),
 	}
@@ -321,9 +326,11 @@ func TestDeleteBinary(t *testing.T) {
 }
 
 func TestGetExecPath(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestGetExecPath")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.PipelinePath = tmp
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.HomePath = tmp
 
 	p := gaia.Pipeline{
 		Name:    "Pipeline A",

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -3,7 +3,7 @@ package scheduler
 import (
 	"crypto/tls"
 	"hash/fnv"
-	"os"
+	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -33,8 +33,9 @@ func (c *CAFake) GetCACertPath() (string, string)                               
 func TestInit(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
 	storeInstance := store.NewBoltStore()
-	gaia.Cfg.DataPath = os.TempDir()
-	gaia.Cfg.WorkspacePath = filepath.Join(os.TempDir(), "tmp")
+	tmp, _ := ioutil.TempDir("", "TestInit")
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.WorkspacePath = filepath.Join(tmp, "tmp")
 	gaia.Cfg.Bolt.Mode = 0600
 	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
 		Level:  hclog.Trace,
@@ -52,17 +53,14 @@ func TestInit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Remove(filepath.Join(os.TempDir(), "gaia.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestPrepareAndExec(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
 	storeInstance := store.NewBoltStore()
-	gaia.Cfg.DataPath = os.TempDir()
-	gaia.Cfg.WorkspacePath = filepath.Join(os.TempDir(), "tmp")
+	tmp, _ := ioutil.TempDir("", "TestPrepareAndExec")
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.WorkspacePath = filepath.Join(tmp, "tmp")
 	gaia.Cfg.Bolt.Mode = 0600
 	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
 		Level:  hclog.Trace,
@@ -88,17 +86,14 @@ func TestPrepareAndExec(t *testing.T) {
 			t.Logf("Job %s has been executed...", job.Title)
 		}
 	}
-	err := os.Remove(filepath.Join(os.TempDir(), "gaia.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestSchedulePipeline(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
 	storeInstance := store.NewBoltStore()
-	gaia.Cfg.DataPath = os.TempDir()
-	gaia.Cfg.WorkspacePath = filepath.Join(os.TempDir(), "tmp")
+	tmp, _ := ioutil.TempDir("", "TestSchedulePipeline")
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.WorkspacePath = filepath.Join(tmp, "tmp")
 	gaia.Cfg.Bolt.Mode = 0600
 	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
 		Level:  hclog.Trace,
@@ -122,18 +117,14 @@ func TestSchedulePipeline(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	err = os.Remove(filepath.Join(os.TempDir(), "gaia.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestSchedule(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
 	storeInstance := store.NewBoltStore()
-	gaia.Cfg.DataPath = os.TempDir()
-	gaia.Cfg.WorkspacePath = filepath.Join(os.TempDir(), "tmp")
+	tmp, _ := ioutil.TempDir("", "TestSchedule")
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.WorkspacePath = filepath.Join(tmp, "tmp")
 	gaia.Cfg.Bolt.Mode = 0600
 	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
 		Level:  hclog.Trace,
@@ -161,17 +152,14 @@ func TestSchedule(t *testing.T) {
 	if r.Status != gaia.RunScheduled {
 		t.Fatalf("run has status %s but should be %s\n", r.Status, string(gaia.RunScheduled))
 	}
-	err = os.Remove(filepath.Join(os.TempDir(), "gaia.db"))
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestSetPipelineJobs(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
 	storeInstance := store.NewBoltStore()
-	gaia.Cfg.DataPath = os.TempDir()
-	gaia.Cfg.WorkspacePath = filepath.Join(os.TempDir(), "tmp")
+	tmp, _ := ioutil.TempDir("", "TestSetPipelineJobs")
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.WorkspacePath = filepath.Join(tmp, "tmp")
 	gaia.Cfg.Bolt.Mode = 0600
 	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
 		Level:  hclog.Trace,
@@ -192,10 +180,6 @@ func TestSetPipelineJobs(t *testing.T) {
 	}
 	if len(p.Jobs) != 4 {
 		t.Fatalf("Number of jobs should be 4 but was %d\n", len(p.Jobs))
-	}
-	err = os.Remove(filepath.Join(os.TempDir(), "gaia.db"))
-	if err != nil {
-		t.Fatal(err)
 	}
 }
 

--- a/security/ca_test.go
+++ b/security/ca_test.go
@@ -12,7 +12,8 @@ import (
 
 func TestInitCA(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
-	gaia.Cfg.DataPath = os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestInitCA")
+	gaia.Cfg.DataPath = tmp
 
 	c, err := InitCA()
 	if err != nil {

--- a/security/ca_test.go
+++ b/security/ca_test.go
@@ -4,7 +4,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/gaia-pipeline/gaia"
@@ -63,7 +62,8 @@ func TestInitCA(t *testing.T) {
 
 func TestCreateSignedCert(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
-	gaia.Cfg.DataPath = os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCreateSignedCert")
+	gaia.Cfg.DataPath = tmp
 
 	c, err := InitCA()
 	if err != nil {
@@ -122,7 +122,8 @@ func TestCreateSignedCert(t *testing.T) {
 
 func TestGenerateTLSConfig(t *testing.T) {
 	gaia.Cfg = &gaia.Config{}
-	gaia.Cfg.DataPath = os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestGenerateTLSConfig")
+	gaia.Cfg.DataPath = tmp
 
 	c, err := InitCA()
 	if err != nil {

--- a/security/vault.go
+++ b/security/vault.go
@@ -107,6 +107,8 @@ func (v *Vault) SaveSecrets() error {
 	if err != nil {
 		return err
 	}
+	// clear the hash after saving so the system always has a fresh view of the vault.
+	v.data = make(map[string][]byte, 0)
 	return v.storer.Write([]byte(encryptedData))
 }
 

--- a/security/vault_test.go
+++ b/security/vault_test.go
@@ -3,6 +3,7 @@ package security
 import (
 	"bytes"
 	"errors"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
@@ -32,7 +33,7 @@ func (mvs *MockVaultStorer) Write(data []byte) error {
 }
 
 func TestNewVault(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestNewVault")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
@@ -52,7 +53,7 @@ func TestNewVault(t *testing.T) {
 }
 
 func TestAddAndGet(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestAddAndGet")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
@@ -77,7 +78,7 @@ func TestAddAndGet(t *testing.T) {
 }
 
 func TestCloseLoadSecrets(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCloseLoadSecrets")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
@@ -112,7 +113,7 @@ func TestCloseLoadSecrets(t *testing.T) {
 }
 
 func TestCloseLoadSecretsWithInvalidPassword(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCloseLoadSecretsWithInvalidPassword")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
@@ -189,8 +190,14 @@ func TestAnExistingVaultFileIsNotOverwritten(t *testing.T) {
 }
 
 func TestRemovingFromTheVault(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestRemovingFromTheVault")
 	gaia.Cfg = &gaia.Config{}
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
 	c, _ := InitCA()
@@ -230,10 +237,16 @@ func TestRemovingFromTheVault(t *testing.T) {
 }
 
 func TestGetAll(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestGetAll")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
 	c, _ := InitCA()
 	v, err := NewVault(c, nil)
 	if err != nil {
@@ -258,10 +271,16 @@ func TestGetAll(t *testing.T) {
 }
 
 func TestEditValueWithAddingItAgain(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestEditValueWithAddingItAgain")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
 	c, _ := InitCA()
 	v, _ := NewVault(c, nil)
 	mvs := new(MockVaultStorer)
@@ -281,10 +300,16 @@ func TestEditValueWithAddingItAgain(t *testing.T) {
 }
 
 func TestReadErrorForVault(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestReadErrorForVault")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
 	c, _ := InitCA()
 	v, _ := NewVault(c, nil)
 	mvs := new(MockVaultStorer)
@@ -300,10 +325,16 @@ func TestReadErrorForVault(t *testing.T) {
 }
 
 func TestWriteErrorForVault(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestWriteErrorForVault")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
 	c, _ := InitCA()
 	v, _ := NewVault(c, nil)
 	mvs := new(MockVaultStorer)
@@ -319,10 +350,16 @@ func TestWriteErrorForVault(t *testing.T) {
 }
 
 func TestDefaultStorerIsAFileStorer(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestDefaultStorerIsAFileStorer")
 	gaia.Cfg = &gaia.Config{}
 	gaia.Cfg.VaultPath = tmp
 	gaia.Cfg.CAPath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
 	c, _ := InitCA()
 	v, _ := NewVault(c, nil)
 	if _, ok := v.storer.(*FileVaultStorer); !ok {

--- a/services/service_provider.go
+++ b/services/service_provider.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"reflect"
+
 	"github.com/gaia-pipeline/gaia"
 	"github.com/gaia-pipeline/gaia/plugin"
 	"github.com/gaia-pipeline/gaia/scheduler"
@@ -26,7 +28,7 @@ var vaultService security.VaultAPI
 // initialized once in the main.go. If it wouldn't work, main would
 // os.Exit(1) and the rest of the application would just stop.
 func StorageService() (store.GaiaStore, error) {
-	if storeService != nil {
+	if storeService != nil && !reflect.ValueOf(storeService).IsNil() {
 		return storeService, nil
 	}
 	storeService = store.NewBoltStore()
@@ -52,7 +54,7 @@ func MockStorageService(store store.GaiaStore) {
 // initialized once in the main.go. If it wouldn't work, main would
 // os.Exit(1) and the rest of the application would just stop.
 func SchedulerService() (scheduler.GaiaScheduler, error) {
-	if schedulerService != nil {
+	if schedulerService != nil && !reflect.ValueOf(schedulerService).IsNil() {
 		return schedulerService, nil
 	}
 	pS := &plugin.Plugin{}
@@ -73,7 +75,7 @@ func MockSchedulerService(scheduler scheduler.GaiaScheduler) {
 
 // CertificateService creates a certificate manager service.
 func CertificateService() (security.CAAPI, error) {
-	if certificateService != nil {
+	if certificateService != nil && !reflect.ValueOf(certificateService).IsNil() {
 		return certificateService, nil
 	}
 
@@ -94,7 +96,7 @@ func MockCertificateService(service security.CAAPI) {
 
 // VaultService creates a vault manager service.
 func VaultService(vaultStore security.VaultStorer) (security.VaultAPI, error) {
-	if vaultService != nil {
+	if vaultService != nil && !reflect.ValueOf(vaultService).IsNil() {
 		return vaultService, nil
 	}
 

--- a/services/service_provider_test.go
+++ b/services/service_provider_test.go
@@ -2,7 +2,7 @@ package services
 
 import (
 	"bytes"
-	"os"
+	"io/ioutil"
 	"testing"
 
 	"github.com/gaia-pipeline/gaia"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStorageService(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestStorageService")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	gaia.Cfg.DataPath = tmp
@@ -31,7 +31,7 @@ func TestStorageService(t *testing.T) {
 }
 
 func TestSchedulerService(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestSchedulerService")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	gaia.Cfg.DataPath = tmp
@@ -52,7 +52,7 @@ func TestSchedulerService(t *testing.T) {
 }
 
 func TestVaultService(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestVaultService")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	gaia.Cfg.DataPath = tmp
@@ -80,7 +80,7 @@ func TestVaultService(t *testing.T) {
 }
 
 func TestCertificateService(t *testing.T) {
-	tmp := os.TempDir()
+	tmp, _ := ioutil.TempDir("", "TestCertificateService")
 	gaia.Cfg = new(gaia.Config)
 	gaia.Cfg.HomePath = tmp
 	gaia.Cfg.DataPath = tmp

--- a/services/service_provider_test.go
+++ b/services/service_provider_test.go
@@ -3,9 +3,14 @@ package services
 import (
 	"bytes"
 	"io/ioutil"
+	"reflect"
 	"testing"
 
+	"github.com/gaia-pipeline/gaia/scheduler"
+	"github.com/gaia-pipeline/gaia/security"
+
 	"github.com/gaia-pipeline/gaia"
+	"github.com/gaia-pipeline/gaia/store"
 	hclog "github.com/hashicorp/go-hclog"
 )
 
@@ -100,4 +105,94 @@ func TestCertificateService(t *testing.T) {
 	if certificateService == nil {
 		t.Fatal("service should not be nil")
 	}
+}
+
+type testMockStorageService struct {
+	store.GaiaStore
+}
+
+type testMockScheduleService struct {
+	scheduler.GaiaScheduler
+}
+
+type testMockCertificateService struct {
+	security.CAAPI
+}
+
+type testMockVaultService struct {
+	security.VaultAPI
+}
+
+func TestCanMockServiceToNil(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "TestCanMockServiceToNil")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	gaia.Cfg.DataPath = tmp
+	gaia.Cfg.CAPath = tmp
+	gaia.Cfg.VaultPath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
+	if certificateService != nil {
+		t.Fatal("initial service should be nil. was: ", certificateService)
+	}
+
+	t.Run("can mock storage to nil", func(t *testing.T) {
+		mcp := new(testMockStorageService)
+		MockStorageService(mcp)
+		s1, _ := StorageService()
+		if reflect.TypeOf(s1).String() != "*services.testMockStorageService" {
+			t.Fatalf("want type: '%s' got: '%s'", "testMockStorageService", reflect.TypeOf(s1).String())
+		}
+		MockStorageService(nil)
+		s2, _ := StorageService()
+		if reflect.TypeOf(s2).String() == "*services.testMockStorageService" {
+			t.Fatalf("want type: '%s' got: '%s'", "BoltStorage", reflect.TypeOf(s2).String())
+		}
+	})
+
+	t.Run("can mock scheduler to nil", func(t *testing.T) {
+		mcp := new(testMockScheduleService)
+		MockSchedulerService(mcp)
+		s1, _ := SchedulerService()
+		if reflect.TypeOf(s1).String() != "*services.testMockScheduleService" {
+			t.Fatalf("want type: '%s' got: '%s'", "testMockScheduleService", reflect.TypeOf(s1).String())
+		}
+		MockSchedulerService(nil)
+		s2, _ := SchedulerService()
+		if reflect.TypeOf(s2).String() == "*services.testMockScheduleService" {
+			t.Fatalf("got: '%s'", reflect.TypeOf(s2).String())
+		}
+	})
+
+	t.Run("can mock certificate to nil", func(t *testing.T) {
+		mcp := new(testMockCertificateService)
+		MockCertificateService(mcp)
+		s1, _ := CertificateService()
+		if reflect.TypeOf(s1).String() != "*services.testMockCertificateService" {
+			t.Fatalf("want type: '%s' got: '%s'", "testMockCertificateService", reflect.TypeOf(s1).String())
+		}
+		MockCertificateService(nil)
+		s2, _ := CertificateService()
+		if reflect.TypeOf(s2).String() == "*services.testMockCertificateService" {
+			t.Fatalf("got: '%s'", reflect.TypeOf(s2).String())
+		}
+	})
+
+	t.Run("can mock vault to nil", func(t *testing.T) {
+		mcp := new(testMockVaultService)
+		MockVaultService(mcp)
+		s1, _ := VaultService(nil)
+		if reflect.TypeOf(s1).String() != "*services.testMockVaultService" {
+			t.Fatalf("want type: '%s' got: '%s'", "testMockVaultService", reflect.TypeOf(s1).String())
+		}
+		MockVaultService(nil)
+		s2, _ := VaultService(nil)
+		if reflect.TypeOf(s2).String() == "*services.testMockVaultService" {
+			t.Fatalf("got: '%s'", reflect.TypeOf(s2).String())
+		}
+	})
 }


### PR DESCRIPTION
This PR fixes the following: 

* When tests are sharing services they must clean up after themselves or the next test will use an already initialised service. This means that things like, the location of the database might be cached, or if the service is mocked out, it might not work with the next test. Therefor a `defer func() { services.MockStorageService(nil)}()` is needed for cleanup.
* Some tests are deleting the database file. The services though are only initialised if the underlying service singleton is `nil`. If not, it will just return that, but will fail never the less because the file doesn't exists like the db, or the certificate. Again, a set to nil will fix this problem.
* `os.TempDir` isn't unique enough. There are cases now that the tests step on each other. `ioutil.TempDir("", "TestName")` must be used to ensure semi uniqueness. Maybe add a random number in there.
* Minimal change to use an even smaller repository in tests which only contains fmt instead of the whole world as dependency which made the test slow and clunky.

There might be more cases when running a test something doesn't work. A good first step is add in a defer mock to nil for services that the code might use. Like, vault, or storage.

Also, pro tip... once in a while run `go clean -testcache`! This will erase every cached content and force tests to run. Might surprise you that some tests start to fail even though you though they are passing. Watch out for this tid-bit: `ok      github.com/gaia-pipeline/gaia/handlers  **(cached)**`.