### PR TITLE
Implemented python support

### DIFF
--- a/frontend/client/views/overview/index.vue
+++ b/frontend/client/views/overview/index.vue
@@ -9,7 +9,7 @@
           <div class="outer-box">
             <router-link :to="{ path: '/pipeline/detail', query: { pipelineid: pipeline.p.id }}" class="hoveraction">
               <div class="outer-box-icon-image">
-                <img :src="getImagePath(pipeline.p.type)" class="outer-box-image">
+                <img :src="getImagePath(pipeline.p.type)" class="outer-box-image" v-bind:class="{ 'outer-box-image-python': pipeline.p.type === 'python', 'outer-box-image': pipeline.p.type !== 'python' }">
               </div>
               <div>
                 <span class="subtitle">{{ pipeline.p.name }}</span>
@@ -239,6 +239,15 @@ export default {
   width: 50px;
   height: 50px;
   top: 70%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.outer-box-image-python {
+  position: absolute;
+  width: 50px;
+  height: 40px;
+  top: 53%;
   left: 50%;
   transform: translate(-50%, -50%);
 }

--- a/frontend/client/views/pipeline/create.vue
+++ b/frontend/client/views/pipeline/create.vue
@@ -66,8 +66,8 @@
               <div class="pipelinetype" title="Java" v-tippy="{ arrow : true,  animation : 'shift-away'}" v-on:click="createPipeline.pipeline.type = 'java'" v-bind:class="{ pipelinetypeactive: createPipeline.pipeline.type === 'java' }" data-tippy-hideOnClick="false">
                 <img src="~assets/java.png" class="typeimage">
               </div>
-              <div class="pipelinetype" title="Python (not yet supported)" v-tippy="{ arrow : true,  animation : 'shift-away'}" v-bind:class="{ pipelinetypeactive: createPipeline.pipeline.type === 'python' }" data-tippy-hideOnClick="false">
-                <img src="~assets/python.png" class="typeimage typeimagenotyetsupported">
+              <div class="pipelinetype" title="Python" v-tippy="{ arrow : true,  animation : 'shift-away'}" v-on:click="createPipeline.pipeline.type = 'python'" v-bind:class="{ pipelinetypeactive: createPipeline.pipeline.type === 'python' }" data-tippy-hideOnClick="false">
+                <img src="~assets/python.png" class="typeimage">
               </div>
             </div>
             <div class="content" style="display: flex;">

--- a/gaia.go
+++ b/gaia.go
@@ -31,6 +31,9 @@ const (
 	// PTypeJava java plugin type
 	PTypeJava PipelineType = "java"
 
+	// PTypePython python plugin type
+	PTypePython PipelineType = "python"
+
 	// CreatePipelineFailed status
 	CreatePipelineFailed CreatePipelineType = "failed"
 
@@ -72,6 +75,15 @@ const (
 
 	// LogsFileName represents the file name of the logs output
 	LogsFileName = "output.log"
+
+	// TmpFolder is the temp folder for temporary files
+	TmpFolder = "tmp"
+
+	// TmpPythonFolder is the name of the python temporary folder
+	TmpPythonFolder = "python"
+
+	// TmpGoFolder is the name of the golang temporary folder
+	TmpGoFolder = "golang"
 )
 
 // User is the user object

--- a/pipeline/build_golang.go
+++ b/pipeline/build_golang.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	golangBinaryName = "go"
-	golangFolder     = "golang"
 )
 
 // BuildPipelineGolang is the real implementation of BuildPipeline for golang
@@ -28,7 +27,7 @@ func (b *BuildPipelineGolang) PrepareEnvironment(p *gaia.CreatePipeline) error {
 	uuid := uuid.Must(uuid.NewV4(), nil)
 
 	// Create local temp folder for clone
-	goPath := filepath.Join(gaia.Cfg.HomePath, tmpFolder, golangFolder)
+	goPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpGoFolder)
 	cloneFolder := filepath.Join(goPath, srcFolder, uuid.String())
 	err := os.MkdirAll(cloneFolder, 0700)
 	if err != nil {
@@ -49,7 +48,7 @@ func (b *BuildPipelineGolang) ExecuteBuild(p *gaia.CreatePipeline) error {
 		gaia.Cfg.Logger.Debug("cannot find go executeable", "error", err.Error())
 		return err
 	}
-	goPath := filepath.Join(gaia.Cfg.HomePath, tmpFolder, golangFolder)
+	goPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpGoFolder)
 
 	// Set command args for get dependencies
 	args := []string{

--- a/pipeline/build_java.go
+++ b/pipeline/build_java.go
@@ -33,7 +33,7 @@ func (b *BuildPipelineJava) PrepareEnvironment(p *gaia.CreatePipeline) error {
 	uuid := uuid.Must(uuid.NewV4(), nil)
 
 	// Create local temp folder for clone
-	rootPath := filepath.Join(gaia.Cfg.HomePath, tmpFolder, javaFolder)
+	rootPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, javaFolder)
 	cloneFolder := filepath.Join(rootPath, srcFolder, uuid.String())
 	err := os.MkdirAll(cloneFolder, 0700)
 	if err != nil {

--- a/pipeline/build_python.go
+++ b/pipeline/build_python.go
@@ -14,7 +14,7 @@ import (
 	"github.com/satori/go.uuid"
 )
 
-const (
+var (
 	pythonBinaryName = "python"
 )
 

--- a/pipeline/build_python.go
+++ b/pipeline/build_python.go
@@ -1,0 +1,118 @@
+package pipeline
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gaia-pipeline/gaia"
+	"github.com/gaia-pipeline/gaia/services"
+	"github.com/satori/go.uuid"
+)
+
+const (
+	pythonBinaryName = "python"
+)
+
+// BuildPipelinePython is the real implementation of BuildPipeline for python
+type BuildPipelinePython struct {
+	Type gaia.PipelineType
+}
+
+// PrepareEnvironment prepares the environment before we start the build process.
+func (b *BuildPipelinePython) PrepareEnvironment(p *gaia.CreatePipeline) error {
+	// create uuid for destination folder
+	uuid := uuid.Must(uuid.NewV4(), nil)
+
+	// Create local temp folder for clone
+	rootPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder)
+	cloneFolder := filepath.Join(rootPath, srcFolder, uuid.String())
+	err := os.MkdirAll(cloneFolder, 0700)
+	if err != nil {
+		return err
+	}
+
+	// Set new generated path in pipeline obj for later usage
+	p.Pipeline.Repo.LocalDest = cloneFolder
+	p.Pipeline.UUID = uuid.String()
+	return err
+}
+
+// ExecuteBuild executes the python build process
+func (b *BuildPipelinePython) ExecuteBuild(p *gaia.CreatePipeline) error {
+	// Look for python executeable
+	path, err := exec.LookPath(pythonBinaryName)
+	if err != nil {
+		gaia.Cfg.Logger.Debug("cannot find python executeable", "error", err.Error())
+		return err
+	}
+
+	// Set command args for build distribution package
+	args := []string{
+		"setup.py",
+		"sdist",
+	}
+
+	// Execute and wait until finish or timeout
+	output, err := executeCmd(path, args, os.Environ(), p.Pipeline.Repo.LocalDest)
+	if err != nil {
+		gaia.Cfg.Logger.Debug("cannot generate python distribution package", "error", err.Error(), "output", string(output))
+		p.Output = string(output)
+		return err
+	}
+
+	return nil
+}
+
+// CopyBinary copies the final compiled archive to the
+// destination folder.
+func (b *BuildPipelinePython) CopyBinary(p *gaia.CreatePipeline) error {
+	// find all files in dist folder
+	distFolder := filepath.Join(p.Pipeline.Repo.LocalDest, "dist")
+	files, err := ioutil.ReadDir(distFolder)
+	if err != nil {
+		return err
+	}
+
+	// filter for archives
+	archive := []os.FileInfo{}
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), ".tar.gz") {
+			archive = append(archive, file)
+		}
+	}
+
+	// if we found more or less than one archive we have a problem
+	if len(archive) != 1 {
+		gaia.Cfg.Logger.Debug("cannot copy python package", "foundPackages", len(archive), "archives", files)
+		return errors.New("cannot copy python package: not found")
+	}
+
+	// Define src and destination
+	src := filepath.Join(distFolder, archive[0].Name())
+	dest := filepath.Join(gaia.Cfg.PipelinePath, appendTypeToName(p.Pipeline.Name, p.Pipeline.Type))
+
+	// Copy binary
+	if err := copyFileContents(src, dest); err != nil {
+		return err
+	}
+
+	// Set +x (execution right) for pipeline
+	return os.Chmod(dest, 0766)
+}
+
+// SavePipeline saves the current pipeline configuration.
+func (b *BuildPipelinePython) SavePipeline(p *gaia.Pipeline) error {
+	dest := filepath.Join(gaia.Cfg.PipelinePath, appendTypeToName(p.Name, p.Type))
+	p.ExecPath = dest
+	p.Type = gaia.PTypePython
+	p.Name = strings.TrimSuffix(filepath.Base(dest), typeDelimiter+gaia.PTypePython.String())
+	p.Created = time.Now()
+	// Our pipeline is finished constructing. Save it.
+	storeService, _ := services.StorageService()
+	return storeService.PipelinePut(p)
+}

--- a/pipeline/build_python_test.go
+++ b/pipeline/build_python_test.go
@@ -1,0 +1,195 @@
+package pipeline
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/gaia-pipeline/gaia"
+	"github.com/gaia-pipeline/gaia/services"
+	"github.com/gaia-pipeline/gaia/store"
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+func TestPrepareEnvironmentPython(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "TestPrepareEnvironmentPython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	b := new(BuildPipelinePython)
+	p := new(gaia.CreatePipeline)
+	err := b.PrepareEnvironment(p)
+	if err != nil {
+		t.Fatal("error was not expected when preparing environment: ", err)
+	}
+	var expectedDest = regexp.MustCompile(`^/.*/tmp/python/src/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	if !expectedDest.MatchString(p.Pipeline.Repo.LocalDest) {
+		t.Fatalf("expected destination is '%s', but was '%s'", expectedDest, p.Pipeline.Repo.LocalDest)
+	}
+}
+
+func TestPrepareEnvironmentInvalidPathForMkdirPython(t *testing.T) {
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = "/notexists"
+	b := new(BuildPipelinePython)
+	p := new(gaia.CreatePipeline)
+	err := b.PrepareEnvironment(p)
+	if err == nil {
+		t.Fatal("error was expected but none occurred")
+	}
+}
+
+func TestExecuteBuildPython(t *testing.T) {
+	execCommandContext = fakeExecCommandContext
+	defer func() {
+		execCommandContext = exec.CommandContext
+	}()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildPython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	b := new(BuildPipelinePython)
+	p := new(gaia.CreatePipeline)
+	// go must be existent, python maybe not.
+	pythonBinaryName = "go"
+	err := b.ExecuteBuild(p)
+	if err != nil {
+		t.Fatal("error while running executebuild. none was expected")
+	}
+	expectedBuildArgs := "setup.py,sdist"
+	actualArgs := os.Getenv("CMD_ARGS")
+	if !strings.Contains(actualArgs, expectedBuildArgs) {
+		t.Fatalf("expected args '%s' actual args '%s'", expectedBuildArgs, actualArgs)
+	}
+}
+
+func TestExecuteBuildContextTimeoutPython(t *testing.T) {
+	execCommandContext = fakeExecCommandContext
+	buildKillContext = true
+	defer func() {
+		execCommandContext = exec.CommandContext
+		buildKillContext = false
+	}()
+	tmp, _ := ioutil.TempDir("", "TestExecuteBuildContextTimeoutPython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	// Initialize shared logger
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
+	b := new(BuildPipelinePython)
+	p := new(gaia.CreatePipeline)
+	// go must be existent, mvn maybe not.
+	pythonBinaryName = "go"
+	err := b.ExecuteBuild(p)
+	if err == nil {
+		t.Fatal("no error found while expecting error.")
+	}
+	if err.Error() != "context deadline exceeded" {
+		t.Fatal("context deadline should have been exceeded. was instead: ", err)
+	}
+}
+
+func TestCopyBinaryPython(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "TestCopyBinaryPython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	// Initialize shared logger
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
+	b := new(BuildPipelinePython)
+	p := new(gaia.CreatePipeline)
+	p.Pipeline.Name = "main"
+	p.Pipeline.Type = gaia.PTypePython
+	p.Pipeline.Repo.LocalDest = tmp
+	os.Mkdir(filepath.Join(tmp, "dist"), 0744)
+	src := filepath.Join(tmp, "dist", p.Pipeline.Name+".tar.gz")
+	dst := appendTypeToName(p.Pipeline.Name, p.Pipeline.Type)
+	f, _ := os.Create(src)
+	defer os.RemoveAll(tmp)
+	defer f.Close()
+	defer os.Remove(dst)
+	ioutil.WriteFile(src, []byte("testcontent"), 0666)
+	err := b.CopyBinary(p)
+	if err != nil {
+		t.Fatal("error was not expected when copying binary: ", err)
+	}
+	content, err := ioutil.ReadFile(dst)
+	if err != nil {
+		t.Fatal("error encountered while reading destination file: ", err)
+	}
+	if string(content) != "testcontent" {
+		t.Fatal("file content did not equal src content. was: ", string(content))
+	}
+}
+
+func TestCopyBinarySrcDoesNotExistPython(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "TestCopyBinarySrcDoesNotExistPython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	// Initialize shared logger
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
+	b := new(BuildPipelinePython)
+	p := new(gaia.CreatePipeline)
+	p.Pipeline.Name = "main"
+	p.Pipeline.Type = gaia.PTypePython
+	p.Pipeline.Repo.LocalDest = "/noneexistent"
+	err := b.CopyBinary(p)
+	if err == nil {
+		t.Fatal("error was expected when copying binary but none occurred ")
+	}
+	if err.Error() != "open /noneexistent/dist: no such file or directory" {
+		t.Fatal("a different error occurred then expected: ", err)
+	}
+}
+
+type pythonMockStorer struct {
+	store.GaiaStore
+	Error error
+}
+
+// PipelinePut is a Mock implementation for pipelines
+func (m *pythonMockStorer) PipelinePut(p *gaia.Pipeline) error {
+	return m.Error
+}
+
+func TestSavePipelinePython(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "TestSavePipelinePython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	m := new(pythonMockStorer)
+	services.MockStorageService(m)
+	defer os.Remove(tmp)
+	defer os.Remove("gaia.db")
+	gaia.Cfg.PipelinePath = tmp + "/pipelines/"
+	defer os.Remove(gaia.Cfg.PipelinePath)
+	p := new(gaia.Pipeline)
+	p.Name = "main"
+	p.Type = gaia.PTypePython
+	b := new(BuildPipelinePython)
+	err := b.SavePipeline(p)
+	if err != nil {
+		t.Fatal("something went wrong. wasn't supposed to get error: ", err)
+	}
+	if p.Name != "main" {
+		t.Fatal("name of pipeline didn't equal expected 'main'. was instead: ", p.Name)
+	}
+	if p.Type != gaia.PTypePython {
+		t.Fatal("type of pipeline was not java. instead was: ", p.Type)
+	}
+}

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -43,9 +43,6 @@ type ActivePipelines struct {
 }
 
 const (
-	// Temp folder where we store our temp files during build pipeline.
-	tmpFolder = "tmp"
-
 	// Max minutes until the build process will be interrupted and marked as failed
 	maxTimeoutMinutes = 60
 
@@ -82,6 +79,10 @@ func newBuildPipeline(t gaia.PipelineType) BuildPipeline {
 		}
 	case gaia.PTypeJava:
 		bP = &BuildPipelineJava{
+			Type: t,
+		}
+	case gaia.PTypePython:
+		bP = &BuildPipelinePython{
 			Type: t,
 		}
 	}

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -345,3 +345,18 @@ func TestGetExecPath(t *testing.T) {
 		t.Fatalf("expected execpath to be %s. got %s", expectedPath, execPath)
 	}
 }
+
+func TestNewBuildPipeline(t *testing.T) {
+	goBuildPipeline := newBuildPipeline(gaia.PTypeGolang)
+	if goBuildPipeline == nil {
+		t.Errorf("should be of type %s but is nil\n", gaia.PTypeGolang)
+	}
+	javaBuildPipeline := newBuildPipeline(gaia.PTypeJava)
+	if javaBuildPipeline == nil {
+		t.Errorf("should be of type %s but is nil\n", gaia.PTypeJava)
+	}
+	pythonBuildPipeline := newBuildPipeline(gaia.PTypePython)
+	if pythonBuildPipeline == nil {
+		t.Errorf("should be of type %s but is nil\n", gaia.PTypePython)
+	}
+}

--- a/pipeline/ticker.go
+++ b/pipeline/ticker.go
@@ -103,6 +103,12 @@ func checkActivePipelines() {
 
 					// Pipeline has been changed?
 					if bytes.Compare(p.SHA256Sum, checksum) != 0 {
+						// update pipeline if needed
+						if err = updatePipeline(p); err != nil {
+							gaia.Cfg.Logger.Debug("cannot update pipeline", "error", err.Error(), "pipeline", p)
+							continue
+						}
+
 						// Let us try again to start the plugin and receive all implemented jobs
 						schedulerService.SetPipelineJobs(p)
 
@@ -139,10 +145,19 @@ func checkActivePipelines() {
 
 			// We calculate a SHA256 Checksum and store it.
 			// We use this to estimate if a pipeline has been changed.
-			pipeline.SHA256Sum, err = getSHA256Sum(pipeline.ExecPath)
+			pipelineCheckSum, err := getSHA256Sum(pipeline.ExecPath)
 			if err != nil {
 				gaia.Cfg.Logger.Debug("cannot calculate sha256 checksum for pipeline", "error", err.Error(), "pipeline", pipeline)
 				continue
+			}
+
+			// update pipeline if needed
+			if bytes.Compare(pipeline.SHA256Sum, pipelineCheckSum) != 0 {
+				pipeline.SHA256Sum = pipelineCheckSum
+				if err = updatePipeline(pipeline); err != nil {
+					gaia.Cfg.Logger.Error("cannot update pipeline", "error", err.Error(), "pipeline", pipeline)
+					continue
+				}
 			}
 
 			// Let us try to start the plugin and receive all implemented jobs
@@ -181,6 +196,8 @@ func getPipelineType(n string) (gaia.PipelineType, error) {
 		return gaia.PTypeGolang, nil
 	case gaia.PTypeJava.String():
 		return gaia.PTypeJava, nil
+	case gaia.PTypePython.String():
+		return gaia.PTypePython, nil
 	}
 
 	return gaia.PTypeUnknown, errMissingType

--- a/pipeline/ticker.go
+++ b/pipeline/ticker.go
@@ -112,6 +112,9 @@ func checkActivePipelines() {
 						// Let us try again to start the plugin and receive all implemented jobs
 						schedulerService.SetPipelineJobs(p)
 
+						// Set new pipeline hash
+						p.SHA256Sum = checksum
+
 						// Replace pipeline
 						if ok := GlobalActivePipelines.Replace(*p); !ok {
 							gaia.Cfg.Logger.Debug("cannot replace pipeline in global pipeline list", "pipeline", p)

--- a/pipeline/update_pipeline.go
+++ b/pipeline/update_pipeline.go
@@ -1,0 +1,46 @@
+package pipeline
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/gaia-pipeline/gaia"
+)
+
+// updatePipeline executes update steps dependent on the pipeline type.
+// Some pipeline types may don't require this.
+func updatePipeline(p *gaia.Pipeline) error {
+	switch p.Type {
+	case gaia.PTypePython:
+		// Remove virtual environment if existend
+		virtualEnvPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, p.Name)
+		os.RemoveAll(virtualEnvPath)
+
+		// Create virtual environment
+		path, err := exec.LookPath("virtualenv")
+		if err != nil {
+			return errors.New("cannot find virtualenv executeable")
+		}
+		cmd := exec.Command(path, virtualEnvPath)
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+
+		// copy distribution file to environment and remove pipeline type at the end.
+		// we have to do this otherwise pip will fail.
+		err = copyFileContents(p.ExecPath, filepath.Join(virtualEnvPath, p.Name+".tar.gz"))
+		if err != nil {
+			return err
+		}
+
+		// install plugin in this environment
+		cmd = exec.Command("/bin/sh", "-c", "source bin/activate; python -m pip install "+filepath.Join(virtualEnvPath, p.Name+".tar.gz"))
+		cmd.Dir = virtualEnvPath
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pipeline/update_pipeline.go
+++ b/pipeline/update_pipeline.go
@@ -2,11 +2,21 @@ package pipeline
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 
 	"github.com/gaia-pipeline/gaia"
+)
+
+var (
+	// virtualEnvName is the binary name of virtual environment app.
+	virtualEnvName = "virtualenv"
+
+	// pythonPipInstallCmd is the command used to install the python distribution
+	// package.
+	pythonPipInstallCmd = "source bin/activate; python -m pip install %s.tar.gz"
 )
 
 // updatePipeline executes update steps dependent on the pipeline type.
@@ -19,7 +29,7 @@ func updatePipeline(p *gaia.Pipeline) error {
 		os.RemoveAll(virtualEnvPath)
 
 		// Create virtual environment
-		path, err := exec.LookPath("virtualenv")
+		path, err := exec.LookPath(virtualEnvName)
 		if err != nil {
 			return errors.New("cannot find virtualenv executeable")
 		}
@@ -36,7 +46,7 @@ func updatePipeline(p *gaia.Pipeline) error {
 		}
 
 		// install plugin in this environment
-		cmd = exec.Command("/bin/sh", "-c", "source bin/activate; python -m pip install "+filepath.Join(virtualEnvPath, p.Name+".tar.gz"))
+		cmd = exec.Command("/bin/sh", "-c", fmt.Sprintf(pythonPipInstallCmd, filepath.Join(virtualEnvPath, p.Name)))
 		cmd.Dir = virtualEnvPath
 		if err := cmd.Run(); err != nil {
 			return err

--- a/pipeline/update_pipeline_test.go
+++ b/pipeline/update_pipeline_test.go
@@ -1,0 +1,57 @@
+package pipeline
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gaia-pipeline/gaia"
+	hclog "github.com/hashicorp/go-hclog"
+)
+
+func TestUpdatePipelinePython(t *testing.T) {
+	tmp, _ := ioutil.TempDir("", "TestUpdatePipelinePython")
+	gaia.Cfg = new(gaia.Config)
+	gaia.Cfg.HomePath = tmp
+	buf := new(bytes.Buffer)
+	gaia.Cfg.Logger = hclog.New(&hclog.LoggerOptions{
+		Level:  hclog.Trace,
+		Output: buf,
+		Name:   "Gaia",
+	})
+
+	p1 := gaia.Pipeline{
+		Name:    "PipelinA",
+		Type:    gaia.PTypePython,
+		Created: time.Now(),
+	}
+
+	// Create fake virtualenv folder with temp file
+	virtualEnvPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, p1.Name)
+	err := os.MkdirAll(virtualEnvPath, 0700)
+	if err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(tmp, "PipelineA_python")
+	p1.ExecPath = src
+	defer os.RemoveAll(tmp)
+	ioutil.WriteFile(src, []byte("testcontent"), 0666)
+
+	// fake execution commands
+	virtualEnvName = "mkdir"
+	pythonPipInstallCmd = "echo %s"
+
+	// run
+	err = updatePipeline(&p1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// check if file has been copied to correct place
+	if _, err = os.Stat(filepath.Join(virtualEnvPath, p1.Name+".tar.gz")); err != nil {
+		t.Fatalf("distribution file does not exist: %s", err.Error())
+	}
+}

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -502,9 +502,9 @@ func (s *Scheduler) executeScheduler(r *gaia.PipelineRun, pS Plugin) {
 					}
 				}
 
-				if allWLDone {
-					close(executeScheduler)
+				if allWLDone && !finalize {
 					close(done)
+					close(executeScheduler)
 					close(triggerSave)
 					finished <- true
 					finalize = true

--- a/security/ca.go
+++ b/security/ca.go
@@ -6,7 +6,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/asn1"
 	"encoding/pem"
 	"errors"
 	"io/ioutil"
@@ -138,7 +137,7 @@ func (c *CA) generateCA() error {
 	}
 
 	// Write out key file in PKCS#8 format
-	privateKey, err := marshalPKCS8PrivateKey(key)
+	privateKey, err := x509.MarshalPKCS8PrivateKey(key)
 	if err != nil {
 		return err
 	}
@@ -204,7 +203,7 @@ func (c *CA) CreateSignedCert() (string, string, error) {
 	}
 
 	// Write out key file in PKCS#8 format
-	privateKey, err := marshalPKCS8PrivateKey(priv)
+	privateKey, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
 		return "", "", err
 	}
@@ -255,21 +254,4 @@ func (c *CA) CleanupCerts(crt, key string) error {
 // GetCACertPath returns the path to the cert and key from the root CA.
 func (c *CA) GetCACertPath() (string, string) {
 	return c.caCertPath, c.caKeyPath
-}
-
-// PKCS#8 structure
-type pKCS8Key struct {
-	Version             int
-	PrivateKeyAlgorithm []asn1.ObjectIdentifier
-	PrivateKey          []byte
-}
-
-// MarshalPKCS8PrivateKey generates an PKCS#8 format private key
-func marshalPKCS8PrivateKey(key *rsa.PrivateKey) ([]byte, error) {
-	var pkey pKCS8Key
-	pkey.Version = 0
-	pkey.PrivateKeyAlgorithm = make([]asn1.ObjectIdentifier, 1)
-	pkey.PrivateKeyAlgorithm[0] = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 1, 1}
-	pkey.PrivateKey = x509.MarshalPKCS1PrivateKey(key)
-	return asn1.Marshal(pkey)
 }


### PR DESCRIPTION
Fixes #68 

This feature will set the minimum golang version to 1.10 because I had to switch to `x509.MarshalPKCS8PrivateKey` which was introduced with go 1.10.