### PR TITLE
Added a definitive check for possible password errors.

### DIFF
--- a/security/vault_test.go
+++ b/security/vault_test.go
@@ -138,7 +138,7 @@ func TestCloseLoadSecretsWithInvalidPassword(t *testing.T) {
 		t.Fatal(err)
 	}
 	v.data = make(map[string][]byte, 0)
-	v.cert = []byte("invalid")
+	v.cert = []byte("tset")
 	err = v.LoadSecrets()
 	if err == nil {
 		t.Fatal("error should not have been nil.")


### PR DESCRIPTION
This deals with #120.

Instead of doing this bit: https://github.com/gaia-pipeline/gaia/blob/413494fa79a632c4dace349aebfdb5009eb5bd54/security/vault.go#L256-L261

Now there is a definitive way of checking if the decryption was successful or not.