### PR TITLE
.sort causes a cascading update on the vue component

### DIFF
--- a/frontend/src/views/settings/worker/manage-worker.vue
+++ b/frontend/src/views/settings/worker/manage-worker.vue
@@ -64,7 +64,7 @@
               </span>
             </span>
             <span v-if="props.column.field === 'tags'">
-              <span>{{ $prettifyTags(props.row.tags.sort()) }}</span>
+              <span>{{ $prettifyTags(props.row.tags) }}</span>
             </span>
             <span v-if="props.column.field === 'action'">
               <a title="Deregister Worker" v-tippy="{ arrow : true,  animation : 'shift-away'}"


### PR DESCRIPTION
@michelvocks I can't believe I finally found it. The sort I added on the tags? Apparently vue doesn't like the component being updated mid display. :/ So it does a re-eval on it, which causes another sort, which causes another re-eval... etc.

I have to have a different way of sorting the tags. I tried compute: but there was a different error. I'll make something up, but for now, I'm just removing the sort so everything works again.

BTW This is a new vue addition, the old one didn't do this. :D

Closes #212 