### PR TITLE
[WIP] Fix: Python pipeline fails with non ascii chars in Pipeline name

### DIFF
--- a/workers/pipeline/update_pipeline.go
+++ b/workers/pipeline/update_pipeline.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -35,8 +36,9 @@ var (
 func updatePipeline(p *gaia.Pipeline) error {
 	switch p.Type {
 	case gaia.PTypePython:
+		pNameBase64Encoded := base64.StdEncoding.EncodeToString([]byte(p.Name))
 		// Remove virtual environment if exists
-		virtualEnvPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, p.Name)
+		virtualEnvPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, pNameBase64Encoded)
 		_ = os.RemoveAll(virtualEnvPath)
 
 		// Create virtual environment

--- a/workers/pipeline/update_pipeline_test.go
+++ b/workers/pipeline/update_pipeline_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"bytes"
+	"encoding/base64"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -29,8 +30,9 @@ func TestUpdatePipelinePython(t *testing.T) {
 		Created: time.Now(),
 	}
 
+	pNameBase64Encoded := base64.StdEncoding.EncodeToString([]byte(p1.Name))
 	// Create fake virtualenv folder with temp file
-	virtualEnvPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, p1.Name)
+	virtualEnvPath := filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, pNameBase64Encoded)
 	err := os.MkdirAll(virtualEnvPath, 0700)
 	if err != nil {
 		t.Fatal(err)

--- a/workers/scheduler/create_cmd.go
+++ b/workers/scheduler/create_cmd.go
@@ -1,6 +1,7 @@
 package scheduler
 
 import (
+	"encoding/base64"
 	"os/exec"
 	"path/filepath"
 
@@ -40,7 +41,8 @@ func createPipelineCmd(p *gaia.Pipeline) *exec.Cmd {
 			"-c",
 			". bin/activate; exec " + pythonExecName + " -c \"import pipeline; pipeline.main()\"",
 		}
-		c.Dir = filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, p.Name)
+		pNameBase64Encoded := base64.StdEncoding.EncodeToString([]byte(p.Name))
+		c.Dir = filepath.Join(gaia.Cfg.HomePath, gaia.TmpFolder, gaia.TmpPythonFolder, pNameBase64Encoded)
 	case gaia.PTypeCpp:
 		c.Path = p.ExecPath
 	case gaia.PTypeRuby:


### PR DESCRIPTION
Closes #219 
Use base64 encoded pipeline name for virtual env creation as it fails with non ascii chars.

Refer to issue for more information.