### PR TITLE
Echo groups (fix #252)

### DIFF
--- a/handlers/auth.go
+++ b/handlers/auth.go
@@ -16,24 +16,6 @@ import (
 var (
 	// errNotAuthorized is thrown when user wants to access resource which is protected
 	errNotAuthorized = errors.New("no or invalid jwt token provided. You are not authorized")
-
-	// Non-protected URL paths which are prefix checked
-	nonProtectedPathsPrefix = []string {
-		"/login",
-		"/pipeline/githook",
-		"/trigger",
-		"/worker/register",
-		"/js/",
-		"/img/",
-		"/fonts/",
-		"/css/",
-	}
-
-	// Non-protected URL paths which are explicitly checked
-	nonProtectedPaths = []string {
-		"/",
-		"/favicon.ico",
-	}
 )
 
 // AuthMiddleware is middleware used for each request. Includes functionality that validates the JWT tokens and user
@@ -41,24 +23,6 @@ var (
 func AuthMiddleware(roleAuth *AuthConfig) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			// Check if it matches an explicit paths
-			for _, paths := range nonProtectedPaths {
-				if paths == c.Path() {
-					return next(c)
-				}
-			}
-
-			// Check if it matches an prefix-based paths
-			p := "/api/" + gaia.APIVersion
-			for _, prefix := range nonProtectedPathsPrefix {
-				switch {
-				case strings.HasPrefix(c.Path(), p+prefix):
-					return next(c)
-				case strings.HasPrefix(c.Path(), prefix):
-					return next(c)
-				}
-			}
-
 			token, err := getToken(c)
 			if err != nil {
 				return c.String(http.StatusUnauthorized, err.Error())

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -46,7 +46,7 @@ func (s *GaiaHandler) InitHandlers(e *echo.Echo) error {
 		apiAuthGrp.POST("user", UserAdd)
 		apiAuthGrp.PUT("user/:username/reset-trigger-token", UserResetTriggerToken)
 
-		apiAuthGrp.GET("/permission", PermissionGetAll)
+		apiAuthGrp.GET("permission", PermissionGetAll)
 
 		// Pipelines
 		// Create pipeline provider

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -1,16 +1,15 @@
 package handlers
 
 import (
-	"net/http"
-
 	rice "github.com/GeertJohan/go.rice"
+	"github.com/gaia-pipeline/gaia/helper/rolehelper"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
+	"net/http"
 
 	"github.com/gaia-pipeline/gaia"
 	"github.com/gaia-pipeline/gaia/handlers/providers/pipelines"
 	"github.com/gaia-pipeline/gaia/handlers/providers/workers"
-	"github.com/gaia-pipeline/gaia/helper/rolehelper"
 )
 
 var (
@@ -25,17 +24,21 @@ func (s *GaiaHandler) InitHandlers(e *echo.Echo) error {
 
 	// --- Register handlers at echo instance ---
 
+	authGrp := e.Group("", AuthMiddleware(&AuthConfig{
+		RoleCategories: rolehelper.DefaultUserRoles,
+	}))
+
 	// Endpoints for Gaia primary instance
 	if gaia.Cfg.Mode == gaia.ModeServer {
 		// Users
 		e.POST(p+"login", UserLogin)
-		e.GET(p+"users", UserGetAll)
-		e.POST(p+"user/password", UserChangePassword)
-		e.DELETE(p+"user/:username", UserDelete)
-		e.GET(p+"user/:username/permissions", UserGetPermissions)
-		e.PUT(p+"user/:username/permissions", UserPutPermissions)
-		e.POST(p+"user", UserAdd)
-		e.PUT(p+"user/:username/reset-trigger-token", UserResetTriggerToken)
+		authGrp.GET(p+"users", UserGetAll)
+		authGrp.POST(p+"user/password", UserChangePassword)
+		authGrp.DELETE(p+"user/:username", UserDelete)
+		authGrp.GET(p+"user/:username/permissions", UserGetPermissions)
+		authGrp.PUT(p+"user/:username/permissions", UserPutPermissions)
+		authGrp.POST(p+"user", UserAdd)
+		authGrp.PUT(p+"user/:username/reset-trigger-token", UserResetTriggerToken)
 
 		perms := e.Group(p + "permission")
 		perms.GET("", PermissionGetAll)
@@ -46,38 +49,38 @@ func (s *GaiaHandler) InitHandlers(e *echo.Echo) error {
 			Scheduler:       s.deps.Scheduler,
 			PipelineService: s.deps.PipelineService,
 		})
-		e.POST(p+"pipeline", pipelineProvider.CreatePipeline)
-		e.POST(p+"pipeline/gitlsremote", pipelineProvider.PipelineGitLSRemote)
-		e.GET(p+"pipeline/name", pipelineProvider.PipelineNameAvailable)
+		authGrp.POST(p+"pipeline", pipelineProvider.CreatePipeline)
+		authGrp.POST(p+"pipeline/gitlsremote", pipelineProvider.PipelineGitLSRemote)
+		authGrp.GET(p+"pipeline/name", pipelineProvider.PipelineNameAvailable)
 		e.POST(p+"pipeline/githook", GitWebHook)
-		e.GET(p+"pipeline/created", pipelineProvider.CreatePipelineGetAll)
-		e.GET(p+"pipeline", pipelineProvider.PipelineGetAll)
-		e.GET(p+"pipeline/:pipelineid", pipelineProvider.PipelineGet)
-		e.PUT(p+"pipeline/:pipelineid", pipelineProvider.PipelineUpdate)
-		e.DELETE(p+"pipeline/:pipelineid", pipelineProvider.PipelineDelete)
-		e.POST(p+"pipeline/:pipelineid/start", pipelineProvider.PipelineStart)
-		e.POST(p+"pipeline/:pipelineid/:pipelinetoken/trigger", pipelineProvider.PipelineTrigger)
-		e.PUT(p+"pipeline/:pipelineid/reset-trigger-token", pipelineProvider.PipelineResetToken)
-		e.GET(p+"pipeline/latest", pipelineProvider.PipelineGetAllWithLatestRun)
-		e.POST(p+"pipeline/periodicschedules", pipelineProvider.PipelineCheckPeriodicSchedules)
+		authGrp.GET(p+"pipeline/created", pipelineProvider.CreatePipelineGetAll)
+		authGrp.GET(p+"pipeline", pipelineProvider.PipelineGetAll)
+		authGrp.GET(p+"pipeline/:pipelineid", pipelineProvider.PipelineGet)
+		authGrp.PUT(p+"pipeline/:pipelineid", pipelineProvider.PipelineUpdate)
+		authGrp.DELETE(p+"pipeline/:pipelineid", pipelineProvider.PipelineDelete)
+		authGrp.POST(p+"pipeline/:pipelineid/start", pipelineProvider.PipelineStart)
+		authGrp.POST(p+"pipeline/:pipelineid/:pipelinetoken/trigger", pipelineProvider.PipelineTrigger)
+		authGrp.PUT(p+"pipeline/:pipelineid/reset-trigger-token", pipelineProvider.PipelineResetToken)
+		authGrp.GET(p+"pipeline/latest", pipelineProvider.PipelineGetAllWithLatestRun)
+		authGrp.POST(p+"pipeline/periodicschedules", pipelineProvider.PipelineCheckPeriodicSchedules)
 
 		// Settings
-		e.POST(p+"settings/poll/on", SettingsPollOn)
-		e.POST(p+"settings/poll/off", SettingsPollOff)
-		e.GET(p+"settings/poll", SettingsPollGet)
+		authGrp.POST(p+"settings/poll/on", SettingsPollOn)
+		authGrp.POST(p+"settings/poll/off", SettingsPollOff)
+		authGrp.GET(p+"settings/poll", SettingsPollGet)
 
 		// PipelineRun
-		e.POST(p+"pipelinerun/:pipelineid/:runid/stop", pipelineProvider.PipelineStop)
-		e.GET(p+"pipelinerun/:pipelineid/:runid", pipelineProvider.PipelineRunGet)
-		e.GET(p+"pipelinerun/:pipelineid", pipelineProvider.PipelineGetAllRuns)
-		e.GET(p+"pipelinerun/:pipelineid/latest", pipelineProvider.PipelineGetLatestRun)
-		e.GET(p+"pipelinerun/:pipelineid/:runid/log", pipelineProvider.GetJobLogs)
+		authGrp.POST(p+"pipelinerun/:pipelineid/:runid/stop", pipelineProvider.PipelineStop)
+		authGrp.GET(p+"pipelinerun/:pipelineid/:runid", pipelineProvider.PipelineRunGet)
+		authGrp.GET(p+"pipelinerun/:pipelineid", pipelineProvider.PipelineGetAllRuns)
+		authGrp.GET(p+"pipelinerun/:pipelineid/latest", pipelineProvider.PipelineGetLatestRun)
+		authGrp.GET(p+"pipelinerun/:pipelineid/:runid/log", pipelineProvider.GetJobLogs)
 
 		// Secrets
-		e.GET(p+"secrets", ListSecrets)
-		e.DELETE(p+"secret/:key", RemoveSecret)
-		e.POST(p+"secret", SetSecret)
-		e.PUT(p+"secret/update", SetSecret)
+		authGrp.GET(p+"secrets", ListSecrets)
+		authGrp.DELETE(p+"secret/:key", RemoveSecret)
+		authGrp.POST(p+"secret", SetSecret)
+		authGrp.PUT(p+"secret/update", SetSecret)
 	}
 
 	// Worker
@@ -86,20 +89,17 @@ func (s *GaiaHandler) InitHandlers(e *echo.Echo) error {
 		Scheduler:   s.deps.Scheduler,
 		Certificate: s.deps.Certificate,
 	})
-	e.GET(p+"worker/secret", workerProvider.GetWorkerRegisterSecret)
+	authGrp.GET(p+"worker/secret", workerProvider.GetWorkerRegisterSecret)
 	e.POST(p+"worker/register", workerProvider.RegisterWorker)
-	e.GET(p+"worker/status", workerProvider.GetWorkerStatusOverview)
-	e.GET(p+"worker", workerProvider.GetWorker)
-	e.DELETE(p+"worker/:workerid", workerProvider.DeregisterWorker)
-	e.POST(p+"worker/secret", workerProvider.ResetWorkerRegisterSecret)
+	authGrp.GET(p+"worker/status", workerProvider.GetWorkerStatusOverview)
+	authGrp.GET(p+"worker", workerProvider.GetWorker)
+	authGrp.DELETE(p+"worker/:workerid", workerProvider.DeregisterWorker)
+	authGrp.POST(p+"worker/secret", workerProvider.ResetWorkerRegisterSecret)
 
 	// Middleware
 	e.Use(middleware.Recover())
-	//e.Use(middleware.Logger())
+	// e.Use(middleware.Logger())
 	e.Use(middleware.BodyLimit("32M"))
-	e.Use(AuthMiddleware(&AuthConfig{
-		RoleCategories: rolehelper.DefaultUserRoles,
-	}))
 
 	// Extra options
 	e.HideBanner = true


### PR DESCRIPTION
So this utilises echo groups to manage what endpoints have the auth middleware applied. This is nice a clean and lets us avoid using the nonProtectedPathsPrefix and nonProtectedPaths slices on every request.

Fixes #252.