### PR TITLE
fix: rbac fixes and some refactoring

### DIFF
--- a/security/rbac/api_mappings_test.go
+++ b/security/rbac/api_mappings_test.go
@@ -247,7 +247,7 @@ func Test_RBACAPIMappings(t *testing.T) {
 		},
 	}
 
-	mappings, _ := loadAPIMappings()
+	mappings, _ := LoadAPILookup()
 
 	for _, tt := range test {
 		t.Run(fmt.Sprintf("test mapping route:%s:%s", tt.method, tt.path), func(t *testing.T) {

--- a/security/rbac/endpoint_enforcer.go
+++ b/security/rbac/endpoint_enforcer.go
@@ -12,9 +12,9 @@ type EndpointEnforcer interface {
 	Enforce(username, method, path string, params map[string]string) error
 }
 
-// Enforce uses the echo.Context to enforce RBAC. Uses the apiLookup to apply policies to specific endpoints.
+// Enforce uses the echo.Context to enforce RBAC. Uses the APILookup to apply policies to specific endpoints.
 func (e *enforcerService) Enforce(username, method, path string, params map[string]string) error {
-	group := e.rbacapiLookup
+	group := e.rbacAPILookup
 
 	endpoint, ok := group[path]
 	if !ok {

--- a/security/rbac/endpoint_enforcer_test.go
+++ b/security/rbac/endpoint_enforcer_test.go
@@ -15,7 +15,7 @@ type mockEnforcer struct {
 	casbin.IEnforcer
 }
 
-var mappings = apiLookup{
+var mappings = APILookup{
 	"/api/v1/pipeline/:pipelineid": {
 		Methods: map[string]string{
 			"GET": "pipelines/get",
@@ -45,7 +45,7 @@ func Test_EnforcerService_Enforce_ValidEnforcement(t *testing.T) {
 
 	svc := enforcerService{
 		enforcer:      &mockEnforcer{},
-		rbacapiLookup: mappings,
+		rbacAPILookup: mappings,
 	}
 
 	err := svc.Enforce("admin", "GET", "/api/v1/pipelines/:pipelineid", map[string]string{"pipelineid": "test"})
@@ -62,7 +62,7 @@ func Test_EnforcerService_Enforce_FailedEnforcement(t *testing.T) {
 
 	svc := enforcerService{
 		enforcer:      &mockEnforcer{},
-		rbacapiLookup: mappings,
+		rbacAPILookup: mappings,
 	}
 
 	err := svc.Enforce("failed", "GET", "/api/v1/pipeline/:pipelineid", map[string]string{"pipelineid": "test"})
@@ -79,7 +79,7 @@ func Test_EnforcerService_Enforce_ErrorEnforcement(t *testing.T) {
 
 	svc := enforcerService{
 		enforcer:      &mockEnforcer{},
-		rbacapiLookup: mappings,
+		rbacAPILookup: mappings,
 	}
 
 	err := svc.Enforce("error", "GET", "/api/v1/pipeline/:pipelineid", map[string]string{"pipelineid": "test"})
@@ -96,7 +96,7 @@ func Test_EnforcerService_Enforce_EndpointParamMissing(t *testing.T) {
 
 	svc := enforcerService{
 		enforcer:      &mockEnforcer{},
-		rbacapiLookup: mappings,
+		rbacAPILookup: mappings,
 	}
 
 	err := svc.Enforce("readonly", "GET", "/api/v1/pipeline/:pipelineid", map[string]string{})

--- a/security/rbac/service_test.go
+++ b/security/rbac/service_test.go
@@ -1,0 +1,344 @@
+package rbac
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/casbin/casbin/v2"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCasbinEnforcer struct {
+	casbin.IEnforcer
+	addPolicyFn         func(rules [][]string) (bool, error)
+	getAllSubjectsFn    func() []string
+	deleteFn            func(role string) (bool, error)
+	getRolesForUserFn   func(name string, domain ...string) ([]string, error)
+	getUsersForRoleFn   func(name string, domain ...string) ([]string, error)
+	addRoleForUserFn    func(user string, role string) (bool, error)
+	deleteRoleForUserFn func(user string, role string) (bool, error)
+	deleteUserFn        func(user string) (bool, error)
+}
+
+func (m *mockCasbinEnforcer) AddPolicies(rules [][]string) (bool, error) {
+	return m.addPolicyFn(rules)
+}
+
+func (m *mockCasbinEnforcer) GetAllSubjects() []string {
+	return m.getAllSubjectsFn()
+}
+
+func (m *mockCasbinEnforcer) DeleteRole(role string) (bool, error) {
+	return m.deleteFn(role)
+}
+
+func (m *mockCasbinEnforcer) GetRolesForUser(name string, domain ...string) ([]string, error) {
+	return m.getRolesForUserFn(name, domain...)
+}
+
+func (m *mockCasbinEnforcer) GetUsersForRole(name string, domain ...string) ([]string, error) {
+	return m.getUsersForRoleFn(name, domain...)
+}
+
+func (m *mockCasbinEnforcer) AddRoleForUser(user string, role string) (bool, error) {
+	return m.addRoleForUserFn(user, role)
+}
+
+func (m *mockCasbinEnforcer) DeleteRoleForUser(user string, role string) (bool, error) {
+	return m.deleteRoleForUserFn(user, role)
+}
+
+func (m *mockCasbinEnforcer) DeleteUser(user string) (bool, error) {
+	return m.deleteUserFn(user)
+}
+
+func TestEnforcerService_AddRole_WithMissingPrefix_ReturnsError(t *testing.T) {
+	ce := &mockCasbinEnforcer{}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.AddRole("noprefix", []RoleRule{})
+	require.EqualError(t, err, "role must be prefixed with 'role:'")
+}
+
+func TestEnforcerService_DeleteRole_WithRoleNotExists_ReturnsError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteFn: func(role string) (bool, error) {
+			require.Equal(t, "notexisting", role)
+			return false, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DeleteRole("notexisting")
+	require.EqualError(t, err, "role does not exist")
+}
+
+func TestEnforcerService_DeleteRole_WithError_ReturnsError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteFn: func(role string) (bool, error) {
+			return true, errors.New("an error")
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DeleteRole("role:valid")
+	require.EqualError(t, err, "error deleting role: an error")
+}
+
+func TestEnforcerService_DeleteRole_WithValid_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteFn: func(role string) (bool, error) {
+			require.Equal(t, "role:valid", role)
+			return true, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DeleteRole("role:valid")
+	require.NoError(t, err)
+}
+
+func TestEnforcerService_AddRole_WithNoRulesArgs_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		addPolicyFn: func(rules [][]string) (bool, error) {
+			return true, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.AddRole("role:newrole", []RoleRule{})
+	require.NoError(t, err)
+}
+
+func TestEnforcerService_AddRole_WithValidRules_Success(t *testing.T) {
+	expectedRules := [][]string{{"role:newrole", "ns-a", "act", "*", "allow"}, {"role:newrole", "ns-b", "act", "*", "deny"}}
+
+	ce := &mockCasbinEnforcer{
+		addPolicyFn: func(rules [][]string) (bool, error) {
+			require.EqualValues(t, expectedRules, rules)
+			return true, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.AddRole("role:newrole", []RoleRule{
+		{
+			Namespace: "ns-a",
+			Action:    "act",
+			Resource:  "*",
+			Effect:    "allow",
+		},
+		{
+			Namespace: "ns-b",
+			Action:    "act",
+			Resource:  "*",
+			Effect:    "deny",
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestEnforcerService_GetAllRoles(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		getAllSubjectsFn: func() []string {
+			return []string{"user", "role:admin", "role:test", "user-b", "role:super"}
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	roles := svc.GetAllRoles()
+	require.Equal(t, []string{"role:admin", "role:test", "role:super"}, roles)
+}
+
+func TestEnforcerService_GetUserAttachedRoles_WithError_ReturnsError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		getRolesForUserFn: func(name string, domain ...string) ([]string, error) {
+			return nil, errors.New("an error")
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	_, err := svc.GetUserAttachedRoles("admin")
+	require.EqualError(t, err, "error getting roles for user: an error")
+}
+
+func TestEnforcerService_GetUserAttachedRoles_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		getRolesForUserFn: func(name string, domain ...string) ([]string, error) {
+			require.Equal(t, "admin", name)
+			require.Equal(t, []string(nil), domain)
+			return []string{"role:admin", "role:another"}, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	roles, err := svc.GetUserAttachedRoles("admin")
+	require.NoError(t, err)
+	require.Equal(t, []string{"role:admin", "role:another"}, roles)
+}
+
+func TestEnforcerService_GetRoleAttachedUsers_WithError_ReturnsError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		getUsersForRoleFn: func(name string, domain ...string) ([]string, error) {
+			return nil, errors.New("an error")
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	_, err := svc.GetRoleAttachedUsers("role:admin")
+	require.EqualError(t, err, "error getting users for role: an error")
+}
+
+func TestEnforcerService_GetRoleAttachedUsers_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		getUsersForRoleFn: func(name string, domain ...string) ([]string, error) {
+			require.Equal(t, "role:admin", name)
+			require.Equal(t, []string(nil), domain)
+			return []string{"admin", "sam"}, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	roles, err := svc.GetRoleAttachedUsers("role:admin")
+	require.NoError(t, err)
+	require.Equal(t, []string{"admin", "sam"}, roles)
+}
+
+func TestEnforcerService_AttachRole_WhenAlreadyAttached_ReturnError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		addRoleForUserFn: func(user string, role string) (bool, error) {
+			return true, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.AttachRole("admin", "role:admin")
+	require.EqualError(t, err, "user already has the role attached")
+}
+
+func TestEnforcerService_AttachRole_WhenErrorOccurs_ReturnError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		addRoleForUserFn: func(user string, role string) (bool, error) {
+			return false, errors.New("an error")
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.AttachRole("admin", "role:admin")
+	require.EqualError(t, err, "error attatching role to user: an error")
+}
+
+func TestEnforcerService_AttachRole_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		addRoleForUserFn: func(user string, role string) (bool, error) {
+			require.Equal(t, "admin", user)
+			require.Equal(t, "role:admin", role)
+			return false, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.AttachRole("admin", "role:admin")
+	require.NoError(t, err)
+}
+
+func TestEnforcerService_DetatchRole_WhenNotAttached_ReturnError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteRoleForUserFn: func(user string, role string) (bool, error) {
+			return false, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DetachRole("admin", "role:admin")
+	require.EqualError(t, err, "role not attached to user")
+}
+
+func TestEnforcerService_DetachRole_WhenErrorOccurs_ReturnError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteRoleForUserFn: func(user string, role string) (bool, error) {
+			return false, errors.New("an error")
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DetachRole("admin", "role:admin")
+	require.EqualError(t, err, "error detatching role from user: an error")
+}
+
+func TestEnforcerService_DetachRole_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteRoleForUserFn: func(user string, role string) (bool, error) {
+			require.Equal(t, "admin", user)
+			require.Equal(t, "role:admin", role)
+			return true, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DetachRole("admin", "role:admin")
+	require.NoError(t, err)
+}
+
+func TestEnforcerService_DeleteUser_WhenErrorOccurs_ReturnError(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteUserFn: func(user string) (bool, error) {
+			return false, errors.New("an error")
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DeleteUser("admin")
+	require.EqualError(t, err, "error deleting user: an error")
+}
+
+func TestEnforcerService_DeleteUser_Success(t *testing.T) {
+	ce := &mockCasbinEnforcer{
+		deleteUserFn: func(user string) (bool, error) {
+			require.Equal(t, "admin", user)
+			return false, nil
+		},
+	}
+	apiLookup := APILookup{}
+
+	svc := NewEnforcerSvc(ce, apiLookup)
+
+	err := svc.DeleteUser("admin")
+	require.NoError(t, err)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -261,9 +261,10 @@ func Start() (err error) {
 
 	rbacService, err := initRBACService(store)
 	if err != nil {
-		gaia.Cfg.Logger.Error("error initializing rbac service", "error", err)
+		gaia.Cfg.Logger.Error("error initializing rbac service", "error", err.Error())
 		return err
 	}
+
 	pipelineProvider := pipelines.NewPipelineProvider(pipelines.Dependencies{
 		Scheduler:       schedulerService,
 		PipelineService: pipelineService,
@@ -373,8 +374,7 @@ func initRBACService(store store.GaiaStore) (rbac.Service, error) {
 	if !gaia.Cfg.RBACEnabled {
 		settings, err := store.SettingsGet()
 		if err != nil {
-			gaia.Cfg.Logger.Error("failed to get settings", "error", err.Error())
-			return nil, err
+			return nil, fmt.Errorf("failed to get store settings: %w", err)
 		}
 
 		if !settings.RBACEnabled {
@@ -399,5 +399,6 @@ func initRBACService(store store.GaiaStore) (rbac.Service, error) {
 	}
 
 	enforcer.EnableLog(gaia.Cfg.RBACDebug)
+
 	return rbac.NewEnforcerSvc(enforcer, apiLookup), nil
 }

--- a/static/rbac-policy.csv
+++ b/static/rbac-policy.csv
@@ -5,7 +5,23 @@
 
 p, role:admin, *, *, *, allow
 
-p, role:readonly, *, get, *, allow
+p, role:readonly, pipelines, list-created, *, allow
+p, role:readonly, pipelines, list, *, allow
+p, role:readonly, pipelines, list-latest, *, allow
+p, role:readonly, pipelines, get, *, allow
+p, role:readonly, pipelines:runs, get-latest-run, *, allow
+p, role:readonly, pipelines:runs, get-run, *, allow
+p, role:readonly, pipelines:runs, get-latest, *, allow
+p, role:readonly, pipelines:runs, get-latest-run, *, allow
+p, role:readonly, secrets, list, *, allow
+p, role:readonly, users, list, *, allow
+p, role:readonly, workers, status-list, *, allow
+p, role:readonly, workers, list, *, allow
+p, role:readonly, workers, get-secret, *, allow
+p, role:readonly, workers, get-status, *, allow
+p, role:readonly, settings, get, *, allow
+p, role:readonly, rbac:roles, list, *, allow
+p, role:readonly, rbac:roles, get-attached, *, allow
+p, role:readonly, users, get-roles, *, allow
 
 g, admin, role:admin
-g, readonly, role:readonly


### PR DESCRIPTION
* Call GetAllSubjects() instead for listing RBAC roles. GetAllRoles() only gets roles that have actually been assigned to a user. This is because 'p' policy lines are defined for the roles. 'g' policy lines are for assignment of a role to a user. GetAllRoles() calls the 'g' line at index 2 to list roles.

* Fixed a bug with role:readonly looking for wildcard 'get' action which no longer exists because our actions became more specific - e.g. 'pipelines:runs, get-run' rather than 'pipelines:runs, get'

* Added a check to make sure all newly created roles have a prefix of 'role:x'

* Made the instantiation of the rbac more testable by using DI instead of instantiating concrete resources within the constructor

* Add missing service.go unit tests